### PR TITLE
Improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,37 @@
-FROM golang:alpine
+ARG GO_VERSION=1.17
+ARG ALPINE_VERSION=3.15
+
+# Build stage
+FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} as build
 
 WORKDIR /app
 
-COPY go.mod .
-COPY go.sum .
+COPY go.mod go.sum .
+
 RUN go mod download
 
-COPY . .
+COPY cmd cmd
 
-RUN go build -o /devportal cmd/devportal/main.go
+COPY server server
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-extldflags=-static" \
+    -o /devportal cmd/devportal/main.go
+
+
+# Final stage
+FROM gcr.io/distroless/static as final
+
+USER nonroot:nonroot
+
+WORKDIR /app
+
+COPY --from=build --chown=nonroot:nonroot /app /app
+
+COPY --from=build --chown=nonroot:nonroot /devportal /
+
+COPY web web
 
 EXPOSE 8080
 
-CMD [ "/devportal" ]
+ENTRYPOINT [ "/devportal" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,11 @@
-version: '3'
+version: '3.8'
 services:
   portal:
     build: .
     env_file: .env
 
   nginx:
-    image: nginx:alpine
+    image: nginx:1.20-alpine
     volumes:
       - ./nginx/dev.conf:/etc/nginx/nginx.conf
       - ./nginx/security.conf:/etc/nginx/security.conf


### PR DESCRIPTION
I've made a few changes which I think are interesting (unfortunately adding some complexity too).

> - Improved versioning

Makes it better for reproducibility (which you likely want with Docker) at the cost of minor maintenance work. Same for docker-compose.yaml. 

> - Distroless final image

Produces a very minimal image (w/ multi-stages build) at the cost of slightly higher build time. Particularly a nice fit for statically compiled binaries. The CGO (*ugh*) issue should be addressed I think.

> - Optimized layer caching

We don't want to re-run the layers with `go mod` or `go build` unless a relevant file has been changed. Improves build time occasionally.

> - Rootless

Needless to say, avoiding root wherever possible is still a nice bonus.
